### PR TITLE
Emit errors to the stream.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,7 @@ module.exports = function (options) {
         self.emit('end');
       })
       .catch(function (error) {
-        console.log(error);
-        self.emit('end');
+        self.emit('error', error);
       });
   };
   return es.through(aggregate, scramble);

--- a/index.js
+++ b/index.js
@@ -7,16 +7,14 @@ var jScrambler = require('jscrambler').default;
 var path = require('path');
 
 module.exports = function (options) {
-  var files = {};
-  var filesSrc = [];
-
   options = defaults(options || {}, {
     keys: {}
   });
+
+  var filesSrc = [];
   var aggregate = function (file) {
     if (file.contents) {
       filesSrc.push(file);
-      files[path.relative(process.cwd(), file.path)] = file;
     }
   };
   var scramble = function () {


### PR DESCRIPTION
In my gulp task there is a lot of processes that happens after the jscrambler transformation. Without emitting the error, the pipeline silently continues without the transformed files.

--

I also removed a variable that was only being assigned to and seemed to serve no real purpose.