### PR TITLE
Allow selection of API version

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ module.exports = function (options) {
         applicationId: options.applicationId,
         host: options.host,
         port: options.port,
-        params: options.params
+        params: options.params,
+        jscramblerVersion: options.jscramblerVersion
       }, function (buffer, file) {
         var cwd = options && options.cwd || process.cwd();
         var relativePath = path.relative(cwd, file);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "event-stream": "^3.1.5",
     "gulp-util": "^2.2.14",
-    "jscrambler": "1.1.2",
+    "jscrambler": "^1.2.2",
     "lodash.defaults": "^4.0.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "del": "^0.1.3",
     "gulp": "^3.8.8",
-    "gulp-cli": "^1.2.1",
+    "gulp-cli": "^1.4.0",
     "gulp-mocha": "^1.1.1",
     "mocha": "^1.21.5"
   },


### PR DESCRIPTION
I see no dis-advantage of passing in `.jscramblerVersion` to `.protectAndDownload`.

I also bumped gulp-cli to 1.4.0.