### PR TITLE
Do not catch stream error in the promise stack.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,10 @@ module.exports = function (options) {
         self.emit('end');
       })
       .catch(function (error) {
-        self.emit('error', error);
+        // need to emit in nextTick to avoid the promise catching a re-thrown error
+        process.nextTick(function () {
+          self.emit('error', error);
+        });
       });
   };
   return es.through(aggregate, scramble);


### PR DESCRIPTION
`stream.Transform.prototype.emit` will re-throw errors when there is no handler.

To avoid that re-throw from ending up in a "unhandled promise rejection" it is done in the nextTick so the throw will crash the process, encouraging implementers to handle the error.

--

In shorter terms `.pipe(jScrabler(options))` throwing an error will crash the process instead of creating a `UnhandledPromiseRejectionWarning`.

My bad, should have figured this out before opening #6.